### PR TITLE
Bump mozillazg/mirror-hg-repo from v1 to v2

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -10,13 +10,13 @@ jobs:
     environment: mirror
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 2
+      - name: Setup Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: 2.7
+          python-version: '3.10'
 
       - name: mirror ruamel-yaml
-        uses: "mozillazg/mirror-hg-repo@v1"
+        uses: "mozillazg/mirror-hg-repo@v2"
         with:
           source-hg-repo-url: "http://hg.code.sf.net/p/ruamel-yaml/code"
           destination-git-repo-owner: "pycontribs"
@@ -24,7 +24,7 @@ jobs:
           destination-git-personal-token: "${{ secrets.PERSONAL_GIT_TOKEN }}"
 
       - name: mirror ruamel-yaml-clib
-        uses: "mozillazg/mirror-hg-repo@v1"
+        uses: "mozillazg/mirror-hg-repo@v2"
         with:
           source-hg-repo-url: "http://hg.code.sf.net/p/ruamel-yaml-clib/code"
           destination-git-repo-owner: "pycontribs"


### PR DESCRIPTION
This version supports Python 3:
https://github.com/mozillazg/mirror-hg-repo/issues/19